### PR TITLE
Golang 版本的 PTX API 使用範例

### DIFF
--- a/Golang/lib/ptxAuthGenerator.go
+++ b/Golang/lib/ptxAuthGenerator.go
@@ -1,0 +1,40 @@
+package lib
+
+import (
+	"time"
+	"net/http"
+	"crypto/sha1"
+	"crypto/hmac"
+	"encoding/base64"
+)
+
+
+func AuthGenerator(APPID, APPKEY string) (string, string){
+	xdate, sign := signGenerator(APPID, APPKEY);
+	auth := "hmac username=\"" + APPID + "\", algorithm=\"hmac-sha1\", headers=\"x-date\", signature=\"" + sign + "\""
+	
+	return xdate, auth
+}
+
+func signGenerator(APPID, APPKEY string) (string, string){
+	xdate := getServerTime()
+	encryptXdate := "x-date: " + xdate
+	encryptSign := hmac_sha1_generator(encryptXdate, APPKEY)
+
+	return xdate, encryptSign
+}
+
+func getServerTime() string {
+	//ptx platform time is GMT 0.
+	timeZone, _ := time.LoadLocation("Europe/London")
+	dt := time.Now().In(timeZone)
+	return dt.Format(http.TimeFormat)
+}
+
+func hmac_sha1_generator(enc_xdate string, appkey string) string{
+	key := []byte(appkey)
+	mac := hmac.New(sha1.New, key)
+	mac.Write([]byte(enc_xdate))
+	mac_encrypted := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	return mac_encrypted
+}

--- a/Golang/lib/ptxService.go
+++ b/Golang/lib/ptxService.go
@@ -1,0 +1,26 @@
+package lib
+
+import "net/http"
+import "io/ioutil"
+
+type PTXService struct{
+	AppID string
+	AppKey string
+}
+
+func (p *PTXService) Get(url string) string{
+
+	//AuthGenerator function is form ./ptxAuthGrenerator.go
+	xdate, auth := AuthGenerator(p.AppID, p.AppKey);
+
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("x-date", xdate)
+	req.Header.Set("Authorization", auth)
+	res, _ := client.Do(req)
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	return string(body)
+}

--- a/Golang/main.go
+++ b/Golang/main.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+import "./lib"
+
+func main(){
+	APPID := "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF";
+	APPKEY := "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF";
+	
+	ptx := lib.PTXService{
+		APPID,
+		APPKEY,
+	}
+
+	//usage
+	fmt.Println(ptx.Get("http://ptx.transportdata.tw/MOTC/v2/Rail/TRA/Station?$top=10&$format=JSON"))
+}

--- a/Golang/readme.md
+++ b/Golang/readme.md
@@ -1,0 +1,52 @@
+# PTX Platform API Wrapper for Golang
+
+## 使用範例
+給予立即需要使用 ptx platform api 的開發者:
+``` go
+//從 local 或 GitHub 上獲取這個 Golang Wrapper
+//若您從 GitHub 上獲取這個專案，請記得使用 go get http://....../lib
+//import "########/lib" 
+
+APPID := "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF";
+APPKEY := "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF";
+
+//您只需要建立 PTXService 物件並置入 APPKEY
+ptx := lib.PTXService{
+    APPID,
+    APPKEY,
+}
+
+//調用 ptx.Get(url) 即可獲得資料
+fmt.Println(ptx.Get("http://ptx.transportdata.tw/MOTC/v2/Rail/TRA/Station?$top=10&$format=JSON"))
+```
+
+## 測試
+拉下專案到桌面，輸入指令執行。
+
+``` shell
+go run main.go
+```
+
+## 手動使用
+若您對內建工具不滿，您也可以只利用 HMAC-SHA1 產生器，省去您重複寫 Auth Token 的時間。
+
+#### 匯入 lib
+``` go
+import "從您的 GitHub 匯入.../lib"
+```
+
+### Common import for local
+``` go
+import "./lib"
+```
+
+#### 使用 AuthGenerator 工具
+``` go
+//直接獲取加密時的 xdate 時間資料及 http head auth token
+xdate, auth := lib.AuthGenerator(APPID, APPKEY);
+
+//自訂 http request 時只要將 xdate, auth 放入下列類似情境:
+// request.setHeader("x-date", xdate)
+// request.setHeader("Authorization", auth)
+```
+


### PR DESCRIPTION
Golang 版本的 PTX API 使用範例

包含了內建的 token 產生工具及能立即使用的物件。