### PR TITLE
Fix server time for Golang example

### DIFF
--- a/Golang/lib/ptxAuthGenerator.go
+++ b/Golang/lib/ptxAuthGenerator.go
@@ -26,9 +26,7 @@ func signGenerator(APPID, APPKEY string) (string, string){
 
 func getServerTime() string {
 	//ptx platform time is GMT 0.
-	timeZone, _ := time.LoadLocation("Europe/London")
-	dt := time.Now().In(timeZone)
-	return dt.Format(http.TimeFormat)
+	return time.Now().UTC().Format(http.TimeFormat)
 }
 
 func hmac_sha1_generator(enc_xdate string, appkey string) string{


### PR DESCRIPTION
因 London 實施 Daylight saving time，修正取得當前時間的方式。

https://github.com/ptxmotc/Sample-code/blob/65c71eec539bfa90e773b25de7609123db26f981/Golang/lib/ptxAuthGenerator.go#L29