### PR TITLE
fix: Remove space in Accept-Encoding

### DIFF
--- a/Python3/auth.py
+++ b/Python3/auth.py
@@ -28,7 +28,7 @@ class Auth():
         return {
             'Authorization': authorization,
             'x-date': format_date_time(mktime(datetime.now().timetuple())),
-            'Accept - Encoding': 'gzip'
+            'Accept-Encoding': 'gzip'
         }
 
 


### PR DESCRIPTION
with `Accept - Encoding` header will get response below:
```
<html>\r\n<head><title>400 Bad Request</title></head>\r\n<body>\r\n<center'
 b'><h1>400 Bad Request</h1></center>\r\n<hr><center>nginx</center>\r\n</bo'
 b'dy>\r\n</html>
```

I used `Accept - Encoding` yesterday and it works great, no idea occur this error today.